### PR TITLE
Fixing filename validation performance regression in launch configuration

### DIFF
--- a/org.epic.debug/src/org/epic/debug/ui/ProjectAndFileBlock.java
+++ b/org.epic.debug/src/org/epic/debug/ui/ProjectAndFileBlock.java
@@ -134,14 +134,13 @@ public class ProjectAndFileBlock extends ProjectBlock
 			setErrorMessage("Startup File is not specified");
 			return false;
 		}
-		String[] files = getPerlFiles();
-		for (int i = 0; i < files.length; i++) {
-			if (files[i].equals(name)) {
-				return true;
-			}
+
+		if (! existsFile(name)) {
+			setErrorMessage("File does not exist or match to the project");
+			return false;
 		}
-		setErrorMessage("File does not exist or match to the project");
-		return false;
+
+		return true;
 	}
     
     private void createScriptFileEditor(Composite parent) {
@@ -190,6 +189,18 @@ public class ProjectAndFileBlock extends ProjectBlock
 			e.printStackTrace();
 		}
 		return ((PerlProjectVisitor) visitor).getList();
+	}
+
+	private boolean existsFile(String filename) {
+		String projectName = getSelectedProject();
+
+		if (projectName == null || projectName.length() == 0) {
+			return false;
+		}
+
+		IWorkspaceRoot workspaceRoot = PerlDebugPlugin.getWorkspace().getRoot();
+		IProject project = workspaceRoot.getProject(projectName);
+		return project.getFile(filename).exists();
 	}
     
     protected void newProjectSelected()

--- a/org.epic.perleditor-test/src/org/epic/core/model/TestSourceFile.java
+++ b/org.epic.perleditor-test/src/org/epic/core/model/TestSourceFile.java
@@ -54,10 +54,10 @@ public class TestSourceFile extends BaseTestCase
                 buf.append(sub.getName());
                 buf.append(':');
                 buf.append(sub.getBlockLevel());
-                buf.append('\n');
+                buf.append(String.format("%n"));
             }
             buf.append('}');
-            buf.append('\n');
+            buf.append(String.format("%n"));
         }
         
         /*

--- a/org.epic.perleditor-test/src/org/epic/perleditor/editors/TestPerlPartitioner.java
+++ b/org.epic.perleditor-test/src/org/epic/perleditor/editors/TestPerlPartitioner.java
@@ -6,9 +6,10 @@ import org.epic.perl.editor.test.Log;
 
 public class TestPerlPartitioner extends BaseTestCase
 {
+    // this test expects unix newlines
     public void testSyntax() throws Exception
     {
-        Document doc = new Document(readFile("workspace/EPICTest/syntax.pl"));
+        Document doc = new Document(readFile("workspace/EPICTest/syntax.pl").replace("\r",""));
         PerlPartitioner partitioner = new PerlPartitioner(new Log(), doc);
 
         ITypedRegion[] partitioning =
@@ -30,7 +31,7 @@ public class TestPerlPartitioner extends BaseTestCase
             buf.append('\n');
         }
         
-        String expected = readFile("test.in/TestPerlPartitioner-expected.txt");
+        String expected = readFile("test.in/TestPerlPartitioner-expected.txt").replace("\r","");
         assertEquals(expected, buf.toString());
         //System.err.println(buf);
     }

--- a/org.epic.perleditor-test/src/org/epic/perleditor/editors/util/PerlValidatorStub.java
+++ b/org.epic.perleditor-test/src/org/epic/perleditor/editors/util/PerlValidatorStub.java
@@ -32,7 +32,7 @@ public class PerlValidatorStub extends PerlValidatorBase
                 throws IOException
             {
                 if (e.getMessage().indexOf("Broken pipe") == 0 ||
-                    e.getMessage().indexOf("Die Pipe wurde beendet") == 0)
+                    e.getMessage().indexOf("Die Pipe ") == 0)
                 {
                     PerlValidatorStub.gotBrokenPipe = true;
                 }

--- a/org.epic.perleditor-test/test.properties
+++ b/org.epic.perleditor-test/test.properties
@@ -2,7 +2,7 @@
 # See README.txt.
 
 # Path to the Perl interpreter
-org.epic.perleditor-test.perl = /usr/bin/perl
+org.epic.perleditor-test.perl = perl
 
 # TestPerlMultiLexer is very machine-specific, disable it to avoid false alarms
 org.epic.perleditor-test.TestPerlMultiLexer.enabled = false


### PR DESCRIPTION
isValid is called on every keystroke, e.g. when inserting command-line parameters. This change fixes creation of monstrous string arrays for comparing with a single filename.
