### PR TITLE
Method::Signature lexing support

### DIFF
--- a/org.epic.perleditor/src/org/epic/core/parser/LexerOptions.java
+++ b/org.epic.perleditor/src/org/epic/core/parser/LexerOptions.java
@@ -1,0 +1,26 @@
+package org.epic.core.parser;
+
+import org.epic.perleditor.PerlEditorPlugin;
+import org.epic.perleditor.preferences.PreferenceConstants;
+
+/**
+ * Constants used as keys for preferences in org.epic.perleditor plugin's
+ * preference store. This class is also responsible for setting the
+ * "factory defaults" for all preferences.
+ */
+public class LexerOptions
+{
+    private LexerOptions()
+    {
+    }
+
+    /**
+     * Returns whether or not to use the Method::Signature handling for lexing
+     *
+     */
+    public static boolean useMethodSignatures()
+    {
+		return PerlEditorPlugin.getDefault().getBooleanPreference(PreferenceConstants.DEBUG_METHOD_SIGNATURES);
+    }
+
+}

--- a/org.epic.perleditor/src/org/epic/core/parser/LexerOptions.java
+++ b/org.epic.perleditor/src/org/epic/core/parser/LexerOptions.java
@@ -4,9 +4,7 @@ import org.epic.perleditor.PerlEditorPlugin;
 import org.epic.perleditor.preferences.PreferenceConstants;
 
 /**
- * Constants used as keys for preferences in org.epic.perleditor plugin's
- * preference store. This class is also responsible for setting the
- * "factory defaults" for all preferences.
+ * A utility class which allows the lexer to refer to options from the editor's preferences page
  */
 public class LexerOptions
 {

--- a/org.epic.perleditor/src/org/epic/core/parser/perl.g
+++ b/org.epic.perleditor/src/org/epic/core/parser/perl.g
@@ -85,7 +85,7 @@ protected SPECIAL_VAR
 	| "$\"" | "$\\"
 
 	| "@+" | "@-" | "@_" | "@$"
-	
+
 	| "%!" | "%@" | "%^H"
 	);
 
@@ -187,7 +187,7 @@ protected SUBST_EXPR
 	{
 		getParent().expectSubstExpr();
 		slashRegexp = qmarkRegexp = false;
-	}; 
+	};
 
 protected MATCH_EXPR
 	: ("qq" | "qx" | "qw" | "qr" | 'm' | 'q')
@@ -384,7 +384,7 @@ OPER_LSHIFT_OR_HEREDOC
 	   { $setType(PerlTokenTypes.OPEN_HEREDOC); }
 	| ("<<=")
 	=> OPER_LSHIFTEQ
-	   { $setToken(createOperatorToken(PerlTokenTypes.OPER_LSHIFTEQ, "<<=")); }	
+	   { $setToken(createOperatorToken(PerlTokenTypes.OPER_LSHIFTEQ, "<<=")); }
 	| ("<<" (WS)? ~('"' | '\'' | '`' | 'A'..'Z'))
 	=> OPER_LSHIFT
 	   { $setToken(createOperatorToken(PerlTokenTypes.OPER_LSHIFT, "<<")); }
@@ -469,9 +469,13 @@ protected WORD
 	: ID
 	{
 		String str = $getText;
-		
+
 		if ("use".equals(str)) $setType(PerlTokenTypes.KEYWORD_USE);
 		else if ("sub".equals(str)) { afterSub = true; $setType(PerlTokenTypes.KEYWORD_SUB); }
+		else if ("func".equals(str) || "method".equals(str))
+		{
+			if (LexerOptions.useMethodSignatures()) { afterSub = true; _ttype = PerlTokenTypes.KEYWORD_SUB; }
+		}
 		else if ("package".equals(str)) { $setType(PerlTokenTypes.KEYWORD_PACKAGE); }
 		else if ("format".equals(str) && !afterSub) { format = true; $setType(PerlTokenTypes.KEYWORD_FORMAT); }
 		else if ("__END__".equals(str)) { $setType(Token.EOF_TYPE); }
@@ -496,7 +500,7 @@ protected WORD
     		}
 		}
 		else glob = false;
-		
+
 		slashRegexp = !(afterArrow || slashRegexp);
 		qmarkRegexp = afterArrow = notOper = false;
 	}
@@ -508,7 +512,7 @@ protected ID
 	{
 		// keep going if we have "::", break on ":"
 		// there must be a better way to implement it X-(
-		if (LA(1) == ':') 
+		if (LA(1) == ':')
 		{
 			if (!afterColon && LA(2) != ':') break;
 			else afterColon = true;

--- a/org.epic.perleditor/src/org/epic/core/parser/perl.g
+++ b/org.epic.perleditor/src/org/epic/core/parser/perl.g
@@ -85,7 +85,7 @@ protected SPECIAL_VAR
 	| "$\"" | "$\\"
 
 	| "@+" | "@-" | "@_" | "@$"
-
+	
 	| "%!" | "%@" | "%^H"
 	);
 
@@ -187,7 +187,7 @@ protected SUBST_EXPR
 	{
 		getParent().expectSubstExpr();
 		slashRegexp = qmarkRegexp = false;
-	};
+	}; 
 
 protected MATCH_EXPR
 	: ("qq" | "qx" | "qw" | "qr" | 'm' | 'q')
@@ -384,7 +384,7 @@ OPER_LSHIFT_OR_HEREDOC
 	   { $setType(PerlTokenTypes.OPEN_HEREDOC); }
 	| ("<<=")
 	=> OPER_LSHIFTEQ
-	   { $setToken(createOperatorToken(PerlTokenTypes.OPER_LSHIFTEQ, "<<=")); }
+	   { $setToken(createOperatorToken(PerlTokenTypes.OPER_LSHIFTEQ, "<<=")); }	
 	| ("<<" (WS)? ~('"' | '\'' | '`' | 'A'..'Z'))
 	=> OPER_LSHIFT
 	   { $setToken(createOperatorToken(PerlTokenTypes.OPER_LSHIFT, "<<")); }
@@ -469,7 +469,7 @@ protected WORD
 	: ID
 	{
 		String str = $getText;
-
+		
 		if ("use".equals(str)) $setType(PerlTokenTypes.KEYWORD_USE);
 		else if ("sub".equals(str)) { afterSub = true; $setType(PerlTokenTypes.KEYWORD_SUB); }
 		else if ("func".equals(str) || "method".equals(str))
@@ -500,7 +500,7 @@ protected WORD
     		}
 		}
 		else glob = false;
-
+		
 		slashRegexp = !(afterArrow || slashRegexp);
 		qmarkRegexp = afterArrow = notOper = false;
 	}
@@ -512,7 +512,7 @@ protected ID
 	{
 		// keep going if we have "::", break on ":"
 		// there must be a better way to implement it X-(
-		if (LA(1) == ':')
+		if (LA(1) == ':') 
 		{
 			if (!afterColon && LA(2) != ':') break;
 			else afterColon = true;

--- a/org.epic.perleditor/src/org/epic/core/preferences/PerlMainPreferencePage.java
+++ b/org.epic.perleditor/src/org/epic/core/preferences/PerlMainPreferencePage.java
@@ -125,7 +125,7 @@ public class PerlMainPreferencePage
 			PerlEditorPlugin.getDefault().getBooleanPreference(
                 PreferenceConstants.DEBUG_SHOW_WARNINGS));
 		warningsCheckBox.setLayoutData(data);
-
+		
 		// Warning preference
 		data = new GridData(GridData.FILL_HORIZONTAL);
 		data.grabExcessHorizontalSpace = true;
@@ -154,7 +154,7 @@ public class PerlMainPreferencePage
         debugConsoleCheckBox.setSelection(
             PerlEditorPlugin.getDefault().getBooleanPreference(
                 PreferenceConstants.DEBUG_DEBUG_CONSOLE));
-        debugConsoleCheckBox.setLayoutData(data);
+        debugConsoleCheckBox.setLayoutData(data);        
 
         // Stop debugger at first line
         data = new GridData(GridData.FILL_HORIZONTAL);
@@ -165,7 +165,7 @@ public class PerlMainPreferencePage
             PerlEditorPlugin.getDefault().getBooleanPreference(
                 PreferenceConstants.DEBUG_SUSPEND_AT_FIRST));
         suspendAtFirstCheckBox.setLayoutData(data);
-
+        
 		//WebBrowser preferences
 		Composite browserComposite = new Composite(top, SWT.NULL);
 		GridLayout browserLayout = new GridLayout();
@@ -173,10 +173,10 @@ public class PerlMainPreferencePage
 		browserComposite.setLayout(browserLayout);
 		data = new GridData(GridData.FILL_BOTH | GridData.VERTICAL_ALIGN_BEGINNING);
 		browserComposite.setLayoutData(data);
-
+		
 		Label browserLabel=new Label(browserComposite, SWT.NONE);
 		browserLabel.setText("Default Web-Start page:");
-
+		
 		data = new GridData(GridData.FILL_HORIZONTAL);
 		data.grabExcessHorizontalSpace = true;
 		browserLabelText = new Text(browserComposite, SWT.BORDER);
@@ -192,10 +192,10 @@ public class PerlMainPreferencePage
         idKeysComposite.setLayout(idKeysLayout);
         data = new GridData(GridData.FILL_BOTH | GridData.VERTICAL_ALIGN_BEGINNING);
         idKeysComposite.setLayoutData(data);
-
+        
         Label debugPreviewKeysLabel = new Label(browserComposite, SWT.NONE);
         debugPreviewKeysLabel.setText("Debugger preview keys:");
-
+        
         data = new GridData(GridData.FILL_HORIZONTAL);
         data.grabExcessHorizontalSpace = true;
         debugPreviewKeysText = new Text(browserComposite, SWT.BORDER);
@@ -203,7 +203,7 @@ public class PerlMainPreferencePage
         debugPreviewKeysText.setText(
             PerlEditorPlugin.getDefault().getPreferenceStore().getString(
                 PreferenceConstants.DEBUG_PREVIEW_KEYS));
-
+		
 		Composite syntaxIntervalComposite = new Composite(top, SWT.NULL);
 
 		GridLayout syncIntervalLayout = new GridLayout();
@@ -218,23 +218,23 @@ public class PerlMainPreferencePage
 		validateCheckBox.setText("Validate source when idle for ");
 		validateCheckBox.setSelection(
             PerlEditorPlugin.getDefault().getBooleanPreference(
-                PreferenceConstants.EDITOR_SYNTAX_VALIDATION));
+                PreferenceConstants.EDITOR_SYNTAX_VALIDATION));	
 		syntaxCheckInterval = new Scale(syntaxIntervalComposite, SWT.HORIZONTAL);
 		syntaxCheckInterval.setMinimum(1);
 		syntaxCheckInterval.setMaximum(10000);
 		syntaxCheckInterval.setIncrement(100);
-
+		
 		syntaxIntervalSecondsLabel = new Label(syntaxIntervalComposite, SWT.NONE);
         displayInterval(PerlEditorPlugin.getDefault().getPreferenceStore().getInt(
             PreferenceConstants.EDITOR_SYNTAX_VALIDATION_INTERVAL));
-
+		
 		syntaxCheckInterval.addListener(SWT.Selection, new Listener () {
             public void handleEvent (Event event)
             {
                 displayInterval(syntaxCheckInterval.getSelection());
             } });
-
-
+			
+		
 		syntaxIntervalComposite.setLayoutData(data);
 
 		return new Composite(parent, SWT.NULL);
@@ -249,14 +249,14 @@ public class PerlMainPreferencePage
 	}
 
 	/**
-	 * Performs special processing when this page's Restore Defaults button has
+	 * Performs special processing when this page's Restore Defaults button has 
 	 * been pressed.
 	 * Sets the contents of the color field to the default value in the preference
 	 * store.
 	 */
 	protected void performDefaults() {
         IPreferenceStore prefs = PerlEditorPlugin.getDefault().getPreferenceStore();
-
+        
 		executableText.setText(
 			prefs.getDefaultString(PreferenceConstants.DEBUG_PERL_EXECUTABLE));
 		warningsCheckBox.setSelection(
@@ -281,13 +281,13 @@ public class PerlMainPreferencePage
             PreferenceConstants.EDITOR_SYNTAX_VALIDATION_INTERVAL);
         displayInterval(defaultInterval);
 	}
-	/**
+	/** 
 	 * Method declared on IPreferencePage. Save the
 	 * color preference to the preference store.
 	 */
 	public boolean performOk() {
         IPreferenceStore prefs = PerlEditorPlugin.getDefault().getPreferenceStore();
-
+        
 		PerlEditorPlugin.getDefault().setPerlExecutable(
 			executableText.getText());
         prefs.setValue(
@@ -320,10 +320,10 @@ public class PerlMainPreferencePage
         prefs.setValue(
             PreferenceConstants.DEBUG_PREVIEW_KEYS,
             debugPreviewKeysText.getText());
-
+		
 		return super.performOk();
 	}
-
+    
     private void displayInterval(int interval)
     {
         float intervalDisplay = Math.round(interval/10f)/100f;

--- a/org.epic.perleditor/src/org/epic/core/preferences/PerlMainPreferencePage.java
+++ b/org.epic.perleditor/src/org/epic/core/preferences/PerlMainPreferencePage.java
@@ -24,6 +24,7 @@ public class PerlMainPreferencePage
 	private Text browserLabelText;
 	private Text debugPreviewKeysText;
 	private Button warningsCheckBox;
+	private Button methodsCheckBox;
 	private Button taintCheckBox;
     private Button debugConsoleCheckBox;
     private Button suspendAtFirstCheckBox;
@@ -124,7 +125,17 @@ public class PerlMainPreferencePage
 			PerlEditorPlugin.getDefault().getBooleanPreference(
                 PreferenceConstants.DEBUG_SHOW_WARNINGS));
 		warningsCheckBox.setLayoutData(data);
-		
+
+		// Warning preference
+		data = new GridData(GridData.FILL_HORIZONTAL);
+		data.grabExcessHorizontalSpace = true;
+		methodsCheckBox = new Button(top, SWT.CHECK);
+		methodsCheckBox.setText("Enable Method::Signature keywords");
+		methodsCheckBox.setSelection(
+			PerlEditorPlugin.getDefault().getBooleanPreference(
+                PreferenceConstants.DEBUG_METHOD_SIGNATURES));
+		methodsCheckBox.setLayoutData(data);
+
 		// Taint check preference
 		data = new GridData(GridData.FILL_HORIZONTAL);
 		data.grabExcessHorizontalSpace = true;
@@ -143,7 +154,7 @@ public class PerlMainPreferencePage
         debugConsoleCheckBox.setSelection(
             PerlEditorPlugin.getDefault().getBooleanPreference(
                 PreferenceConstants.DEBUG_DEBUG_CONSOLE));
-        debugConsoleCheckBox.setLayoutData(data);        
+        debugConsoleCheckBox.setLayoutData(data);
 
         // Stop debugger at first line
         data = new GridData(GridData.FILL_HORIZONTAL);
@@ -154,7 +165,7 @@ public class PerlMainPreferencePage
             PerlEditorPlugin.getDefault().getBooleanPreference(
                 PreferenceConstants.DEBUG_SUSPEND_AT_FIRST));
         suspendAtFirstCheckBox.setLayoutData(data);
-        
+
 		//WebBrowser preferences
 		Composite browserComposite = new Composite(top, SWT.NULL);
 		GridLayout browserLayout = new GridLayout();
@@ -162,10 +173,10 @@ public class PerlMainPreferencePage
 		browserComposite.setLayout(browserLayout);
 		data = new GridData(GridData.FILL_BOTH | GridData.VERTICAL_ALIGN_BEGINNING);
 		browserComposite.setLayoutData(data);
-		
+
 		Label browserLabel=new Label(browserComposite, SWT.NONE);
 		browserLabel.setText("Default Web-Start page:");
-		
+
 		data = new GridData(GridData.FILL_HORIZONTAL);
 		data.grabExcessHorizontalSpace = true;
 		browserLabelText = new Text(browserComposite, SWT.BORDER);
@@ -181,10 +192,10 @@ public class PerlMainPreferencePage
         idKeysComposite.setLayout(idKeysLayout);
         data = new GridData(GridData.FILL_BOTH | GridData.VERTICAL_ALIGN_BEGINNING);
         idKeysComposite.setLayoutData(data);
-        
+
         Label debugPreviewKeysLabel = new Label(browserComposite, SWT.NONE);
         debugPreviewKeysLabel.setText("Debugger preview keys:");
-        
+
         data = new GridData(GridData.FILL_HORIZONTAL);
         data.grabExcessHorizontalSpace = true;
         debugPreviewKeysText = new Text(browserComposite, SWT.BORDER);
@@ -192,7 +203,7 @@ public class PerlMainPreferencePage
         debugPreviewKeysText.setText(
             PerlEditorPlugin.getDefault().getPreferenceStore().getString(
                 PreferenceConstants.DEBUG_PREVIEW_KEYS));
-		
+
 		Composite syntaxIntervalComposite = new Composite(top, SWT.NULL);
 
 		GridLayout syncIntervalLayout = new GridLayout();
@@ -207,23 +218,23 @@ public class PerlMainPreferencePage
 		validateCheckBox.setText("Validate source when idle for ");
 		validateCheckBox.setSelection(
             PerlEditorPlugin.getDefault().getBooleanPreference(
-                PreferenceConstants.EDITOR_SYNTAX_VALIDATION));	
+                PreferenceConstants.EDITOR_SYNTAX_VALIDATION));
 		syntaxCheckInterval = new Scale(syntaxIntervalComposite, SWT.HORIZONTAL);
 		syntaxCheckInterval.setMinimum(1);
 		syntaxCheckInterval.setMaximum(10000);
 		syntaxCheckInterval.setIncrement(100);
-		
+
 		syntaxIntervalSecondsLabel = new Label(syntaxIntervalComposite, SWT.NONE);
         displayInterval(PerlEditorPlugin.getDefault().getPreferenceStore().getInt(
             PreferenceConstants.EDITOR_SYNTAX_VALIDATION_INTERVAL));
-		
+
 		syntaxCheckInterval.addListener(SWT.Selection, new Listener () {
             public void handleEvent (Event event)
             {
                 displayInterval(syntaxCheckInterval.getSelection());
             } });
-			
-		
+
+
 		syntaxIntervalComposite.setLayoutData(data);
 
 		return new Composite(parent, SWT.NULL);
@@ -238,18 +249,20 @@ public class PerlMainPreferencePage
 	}
 
 	/**
-	 * Performs special processing when this page's Restore Defaults button has 
+	 * Performs special processing when this page's Restore Defaults button has
 	 * been pressed.
 	 * Sets the contents of the color field to the default value in the preference
 	 * store.
 	 */
 	protected void performDefaults() {
         IPreferenceStore prefs = PerlEditorPlugin.getDefault().getPreferenceStore();
-        
+
 		executableText.setText(
 			prefs.getDefaultString(PreferenceConstants.DEBUG_PERL_EXECUTABLE));
 		warningsCheckBox.setSelection(
 			prefs.getDefaultBoolean(PreferenceConstants.DEBUG_SHOW_WARNINGS));
+		methodsCheckBox.setSelection(
+			prefs.getDefaultBoolean(PreferenceConstants.DEBUG_METHOD_SIGNATURES));
 		taintCheckBox.setSelection(
             prefs.getDefaultBoolean(PreferenceConstants.DEBUG_TAINT_MODE));
         debugConsoleCheckBox.setSelection(
@@ -268,18 +281,21 @@ public class PerlMainPreferencePage
             PreferenceConstants.EDITOR_SYNTAX_VALIDATION_INTERVAL);
         displayInterval(defaultInterval);
 	}
-	/** 
+	/**
 	 * Method declared on IPreferencePage. Save the
 	 * color preference to the preference store.
 	 */
 	public boolean performOk() {
         IPreferenceStore prefs = PerlEditorPlugin.getDefault().getPreferenceStore();
-        
+
 		PerlEditorPlugin.getDefault().setPerlExecutable(
 			executableText.getText());
         prefs.setValue(
             PreferenceConstants.DEBUG_SHOW_WARNINGS,
             warningsCheckBox.getSelection());
+        prefs.setValue(
+            PreferenceConstants.DEBUG_METHOD_SIGNATURES,
+            methodsCheckBox.getSelection());
 		prefs.setValue(
             PreferenceConstants.DEBUG_TAINT_MODE,
 			taintCheckBox.getSelection());
@@ -304,10 +320,10 @@ public class PerlMainPreferencePage
         prefs.setValue(
             PreferenceConstants.DEBUG_PREVIEW_KEYS,
             debugPreviewKeysText.getText());
-		
+
 		return super.performOk();
 	}
-    
+
     private void displayInterval(int interval)
     {
         float intervalDisplay = Math.round(interval/10f)/100f;

--- a/org.epic.perleditor/src/org/epic/perleditor/preferences/PreferenceConstants.java
+++ b/org.epic.perleditor/src/org/epic/perleditor/preferences/PreferenceConstants.java
@@ -22,7 +22,7 @@ public class PreferenceConstants
      * Initial URL displayed in the Browser view
      */
     public static final String BROWSER_START_URL = "WEB_BROWSER";
-    
+
     /**
      * Comma-separated list of hash keys to include first in the content
      * preview of Variables view, useful for ensuring that keys such as
@@ -61,6 +61,11 @@ public class PreferenceConstants
      * validation and script execution
      */
     public static final String DEBUG_SHOW_WARNINGS = "SHOW_WARNINGS";
+
+    /**
+     * Whether or not the lexer should parse 'func' and 'method' as subroutine keywords (from Method::Signatures and the like)
+     */
+    public static final String DEBUG_METHOD_SIGNATURES = "METHOD_SIGNATURES";
 
     /**
      * Whether or not the debugger should suspend at the first executable
@@ -255,7 +260,7 @@ public class PreferenceConstants
      * Value is of type <code>String</code>. A RGB color value encoded as a
      * string using class <code>PreferenceConverter</code>
      * </p>
-     * 
+     *
      * @see org.eclipse.jface.resource.StringConverter
      * @see org.eclipse.jface.preference.PreferenceConverter
      */
@@ -268,7 +273,7 @@ public class PreferenceConstants
      * Value is of type <code>String</code>. A RGB color value encoded as a
      * string using class <code>PreferenceConverter</code>
      * </p>
-     * 
+     *
      * @see org.eclipse.jface.resource.StringConverter
      * @see org.eclipse.jface.preference.PreferenceConverter
      */
@@ -290,7 +295,7 @@ public class PreferenceConstants
      * Value is of type <code>String</code>. A RGB color value encoded as a
      * string using class <code>PreferenceConverter</code>
      * </p>
-     * 
+     *
      * @see org.eclipse.jface.resource.StringConverter
      * @see org.eclipse.jface.preference.PreferenceConverter
      */
@@ -404,7 +409,7 @@ public class PreferenceConstants
      * Value is of type <code>String</code>. A RGB color value encoded as a
      * string using class <code>PreferenceConverter</code>
      * </p>
-     * 
+     *
      * @see org.eclipse.jface.resource.StringConverter
      * @see org.eclipse.jface.preference.PreferenceConverter
      */
@@ -450,7 +455,7 @@ public class PreferenceConstants
 
     /**
      * Initializes the given preference store with the default values.
-     * 
+     *
      * @param store
      *            the preference store to be initialized
      */
@@ -462,6 +467,7 @@ public class PreferenceConstants
             DEBUG_INTERPRETER_TYPE_STANDARD);
         store.setDefault(DEBUG_PERL_EXECUTABLE, "perl"); //$NON-NLS-1$
         store.setDefault(DEBUG_SHOW_WARNINGS, true);
+        store.setDefault(DEBUG_METHOD_SIGNATURES, false);
         store.setDefault(DEBUG_TAINT_MODE, false);
         store.setDefault(DEBUG_DEBUG_CONSOLE, false);
         store.setDefault(DEBUG_SUSPEND_AT_FIRST, true);

--- a/org.epic.perleditor/src/org/epic/perleditor/preferences/PreferenceConstants.java
+++ b/org.epic.perleditor/src/org/epic/perleditor/preferences/PreferenceConstants.java
@@ -22,7 +22,7 @@ public class PreferenceConstants
      * Initial URL displayed in the Browser view
      */
     public static final String BROWSER_START_URL = "WEB_BROWSER";
-
+    
     /**
      * Comma-separated list of hash keys to include first in the content
      * preview of Variables view, useful for ensuring that keys such as
@@ -260,7 +260,7 @@ public class PreferenceConstants
      * Value is of type <code>String</code>. A RGB color value encoded as a
      * string using class <code>PreferenceConverter</code>
      * </p>
-     *
+     * 
      * @see org.eclipse.jface.resource.StringConverter
      * @see org.eclipse.jface.preference.PreferenceConverter
      */
@@ -273,7 +273,7 @@ public class PreferenceConstants
      * Value is of type <code>String</code>. A RGB color value encoded as a
      * string using class <code>PreferenceConverter</code>
      * </p>
-     *
+     * 
      * @see org.eclipse.jface.resource.StringConverter
      * @see org.eclipse.jface.preference.PreferenceConverter
      */
@@ -295,7 +295,7 @@ public class PreferenceConstants
      * Value is of type <code>String</code>. A RGB color value encoded as a
      * string using class <code>PreferenceConverter</code>
      * </p>
-     *
+     * 
      * @see org.eclipse.jface.resource.StringConverter
      * @see org.eclipse.jface.preference.PreferenceConverter
      */
@@ -409,7 +409,7 @@ public class PreferenceConstants
      * Value is of type <code>String</code>. A RGB color value encoded as a
      * string using class <code>PreferenceConverter</code>
      * </p>
-     *
+     * 
      * @see org.eclipse.jface.resource.StringConverter
      * @see org.eclipse.jface.preference.PreferenceConverter
      */
@@ -455,7 +455,7 @@ public class PreferenceConstants
 
     /**
      * Initializes the given preference store with the default values.
-     *
+     * 
      * @param store
      *            the preference store to be initialized
      */


### PR DESCRIPTION
Method::Signatures (and MooseX::Method::Signatures) both ostensibly add keywords to the perl language, func and method.  While these add a great deal of utility for developers, it can be frustrating to use EPIC with a standard perl-only lexing scheme as that keeps outlines and other nice features of the editor from working properly.  The fix I have proposed here adds an option to the preferences pane to enable/disable this departure from Perl-only lexing, and adds the ability for the lexer to pull out func & method as if they were sub.
