### PR TITLE
Bug 668 tweak call stack parser

### DIFF
--- a/org.epic.debug/src/org/epic/debug/db/PerlThreadStack.java
+++ b/org.epic.debug/src/org/epic/debug/db/PerlThreadStack.java
@@ -52,8 +52,17 @@ class PerlThreadStack
                 previousFrames.length > 0
                 ? (StackFrame) previousFrames[0]
                 : null;
-            
-            StackFrame[] frames = new StackFrame[matches.length + 1];
+
+            int skipFirst = 0;
+            if (matches.length > 0) {
+                int firstLineNumber = Integer.parseInt(matches[0].toString(4));
+                if (matches[0].toString(2).startsWith("DB::DB ")
+                        && firstLineNumber == currentIP.getLine()) {
+                    // This is a duplicate, skip.
+                    skipFirst = 1;
+                }
+            }
+            StackFrame[] frames = new StackFrame[matches.length + 1 - skipFirst];
             frames[0] = new StackFrame(
                 thread,
                 currentIP.getPath(),
@@ -63,11 +72,11 @@ class PerlThreadStack
                 previousTopFrame,
                 0);
     
-            for (int pos = 0; pos < matches.length; ++pos)
+            for (int pos = skipFirst; pos < matches.length; ++pos)
             {
                 IPath dbPath = new Path(matches[pos].toString(3));
 
-                frames[pos + 1] = new StackFrame(
+                frames[pos + 1 - skipFirst] = new StackFrame(
                     thread,
                     dbPath,
                     Integer.parseInt(matches[pos].toString(4)),

--- a/org.epic.debug/src/org/epic/debug/db/RE.java
+++ b/org.epic.debug/src/org/epic/debug/db/RE.java
@@ -35,7 +35,7 @@ class RE
         ENTER_FRAME = newRE("^\\s*entering", false);
         EXIT_FRAME = newRE("^\\s*exited", false);
         STACK_TRACE = newRE(
-            "(.)\\s+=\\s+(.*)called from .* \\`([^\\']+)\\'\\s*line (\\d+)\\s*",
+            "(.)\\s+=\\s+(.*)called from .* [\\`']([^\\']+)\\'\\s*line (\\d+)\\s*",
             false);
     }
 


### PR DESCRIPTION
This change was tested on linux x86_64, with a vanilla perl 5.12.5 (freshly compiled) and a distributed perl 5.18.2 (debian). It should fix issue http://sourceforge.net/p/e-p-i-c/bugs/668/.

It does two things:
- match the new debugger stack pattern (apostrophe)
- skip the additional DB::DB stack item which is a duplicate of the one obtained from currentIP (hackish but it works)
