### PR TITLE
Support detecting perl files without shebang line

### DIFF
--- a/org.epic.perleditor/src/org/epic/core/content/PerlContentDescriber.java
+++ b/org.epic.perleditor/src/org/epic/core/content/PerlContentDescriber.java
@@ -23,7 +23,7 @@ public class PerlContentDescriber implements ITextContentDescriber
         return
             line == null ||
             !line.startsWith("#!") ||
-            !(line.indexOf("perl") != -1) ? INVALID : VALID;
+            !(line.indexOf("perl") != -1) ? INDETERMINATE : VALID;
     }
 
     public int describe(InputStream contents, IContentDescription description) throws IOException


### PR DESCRIPTION
This enables getting a IContentDescription for pl or pm files that do not
have a shebang line. Even though such descriptions are currently not used
by Eclipse itself for opening editors a third-party may have the need for
going through the content type for finding an editor to open perl files.
