### PR TITLE
Revert "Fix a compile error in PerlValidatorStub"

### DIFF
--- a/org.epic.perleditor-test/src/org/epic/perleditor/editors/util/PerlValidatorStub.java
+++ b/org.epic.perleditor-test/src/org/epic/perleditor/editors/util/PerlValidatorStub.java
@@ -2,7 +2,6 @@ package org.epic.perleditor.editors.util;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.*;
 
 import org.eclipse.core.resources.IResource;
@@ -67,7 +66,7 @@ public class PerlValidatorStub extends PerlValidatorBase
         perlExecutor.dispose();
     }
     
-    protected void addMarker(IResource resource, Map<String, Serializable> attributes)
+    protected void addMarker(IResource resource, Map<String, Object> attributes)
     {
     }
     


### PR DESCRIPTION
Reverts jploski/epic-ide#23

this change needs to be reverted. I was mislead by an error which occured because I had the 0.7.0 release installed and Eclipse was trying to link against that.
