### PR TITLE
Introduce a Logger for exceptions in org.epic.perleditor

### DIFF
--- a/org.epic.perleditor/.options
+++ b/org.epic.perleditor/.options
@@ -1,0 +1,1 @@
+org.epic.perleditor/debug=false

--- a/org.epic.perleditor/src/org/epic/core/decorators/PerlDecorator.java
+++ b/org.epic.perleditor/src/org/epic/core/decorators/PerlDecorator.java
@@ -23,6 +23,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IDecoratorManager;
 import org.eclipse.ui.IEditorDescriptor;
 import org.epic.core.Constants;
+import org.epic.perleditor.Logger;
 import org.epic.perleditor.PerlEditorPlugin;
 
 /**
@@ -82,7 +83,7 @@ public class PerlDecorator extends LabelProvider
                 }
             }
         } catch (CoreException e) {
-            e.printStackTrace();
+            Logger.logException(e);
         }
         
         try {
@@ -94,7 +95,7 @@ public class PerlDecorator extends LabelProvider
                 }
             }
         } catch (CoreException e) {
-            e.printStackTrace();
+            Logger.logException(e);
         }
 
         if (!isPerlProject && defaultEditorDescriptor != null) {
@@ -112,7 +113,7 @@ public class PerlDecorator extends LabelProvider
                 //resource.getProject().accept(projectVisitor);
                 resource.accept(projectVisitor);
             } catch (CoreException e1) {
-                e1.printStackTrace();
+                Logger.logException(e1);
             }
 
             int state = projectVisitor.getState();
@@ -134,7 +135,7 @@ public class PerlDecorator extends LabelProvider
                     }
                 }
             } catch (CoreException e1) {
-                e1.printStackTrace();
+                Logger.logException(e1);
             }
         }
     }
@@ -197,7 +198,7 @@ public class PerlDecorator extends LabelProvider
                 }
             }
         } catch (CoreException e) {
-            e.printStackTrace();
+            Logger.logException(e);
         }
 
         return state;

--- a/org.epic.perleditor/src/org/epic/core/popupmenus/ToggleLibPathActionDelegate.java
+++ b/org.epic.perleditor/src/org/epic/core/popupmenus/ToggleLibPathActionDelegate.java
@@ -9,6 +9,7 @@ import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.ui.IObjectActionDelegate;
 import org.eclipse.ui.IWorkbenchPart;
 import org.epic.core.util.XMLUtilities;
+import org.epic.perleditor.Logger;
 
 public class ToggleLibPathActionDelegate implements IObjectActionDelegate
 {
@@ -78,7 +79,7 @@ public class ToggleLibPathActionDelegate implements IObjectActionDelegate
         }
         catch (IOException e)
         {
-            e.printStackTrace();
+            Logger.logException(e);
             return false;
         }
         return true;
@@ -110,7 +111,7 @@ public class ToggleLibPathActionDelegate implements IObjectActionDelegate
         }
         catch (IOException e)
         {
-            e.printStackTrace();
+            Logger.logException(e);
             return false;
         }
         return true;

--- a/org.epic.perleditor/src/org/epic/core/popupmenus/TogglePerlNatureActionDelegate.java
+++ b/org.epic.perleditor/src/org/epic/core/popupmenus/TogglePerlNatureActionDelegate.java
@@ -17,6 +17,7 @@ import org.eclipse.ui.IWorkbenchPart;
 //import org.eclipse.ui.views.navigator.IResourceNavigator;
 import org.epic.core.Constants;
 import org.epic.core.util.NatureUtilities;
+import org.epic.perleditor.Logger;
 
 /**
  * @author luelljoc
@@ -57,7 +58,7 @@ public class TogglePerlNatureActionDelegate implements IObjectActionDelegate {
                     }
                     action.setEnabled(project.isAccessible());
                 } catch (CoreException e) {
-                    e.printStackTrace();
+                    Logger.logException(e);
                 }
             }
         }
@@ -80,8 +81,7 @@ public class TogglePerlNatureActionDelegate implements IObjectActionDelegate {
                     }
                 }
             } catch (CoreException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
+                Logger.logException(e);
             }
 
         }

--- a/org.epic.perleditor/src/org/epic/core/properties/IgnoredPathsPropertyPage.java
+++ b/org.epic.perleditor/src/org/epic/core/properties/IgnoredPathsPropertyPage.java
@@ -10,6 +10,7 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.*;
 import org.eclipse.ui.dialogs.PropertyPage;
 import org.epic.core.util.XMLUtilities;
+import org.epic.perleditor.Logger;
 
 public class IgnoredPathsPropertyPage extends PropertyPage
 {
@@ -125,7 +126,7 @@ public class IgnoredPathsPropertyPage extends PropertyPage
         }
         catch (Exception e)
         {
-            e.printStackTrace();
+            Logger.logException(e);
             return false;
         }
     }

--- a/org.epic.perleditor/src/org/epic/core/properties/IncludePathPropertyPage.java
+++ b/org.epic.perleditor/src/org/epic/core/properties/IncludePathPropertyPage.java
@@ -14,6 +14,7 @@ import org.eclipse.core.resources.IResource;
 import java.io.File;
 
 import org.epic.core.util.XMLUtilities;
+import org.epic.perleditor.Logger;
 
 public class IncludePathPropertyPage extends PropertyPage {
     //plements IWorkbenchPropertyPage {
@@ -159,7 +160,7 @@ public class IncludePathPropertyPage extends PropertyPage {
             xmlUtil.writeIncludeEntries(project, incPathList.getItems());
             return true;
         } catch (Exception e) {
-            e.printStackTrace();
+            Logger.logException(e);
             return false;
         }
     }

--- a/org.epic.perleditor/src/org/epic/core/util/NatureUtilities.java
+++ b/org.epic.perleditor/src/org/epic/core/util/NatureUtilities.java
@@ -9,6 +9,7 @@ package org.epic.core.util;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.runtime.CoreException;
+import org.epic.perleditor.Logger;
 
 /**
  * @author luelljoc
@@ -27,7 +28,7 @@ public class NatureUtilities {
             description.setNatureIds(newNatures);
             project.setDescription(description, null);
         } catch (CoreException e) {
-            e.printStackTrace();
+            Logger.logException(e);
         }
     }
 
@@ -52,7 +53,7 @@ public class NatureUtilities {
                 project.setDescription(description, null);
             }
         } catch (CoreException e) {
-            e.printStackTrace();
+            Logger.logException(e);
         }
     }
 }

--- a/org.epic.perleditor/src/org/epic/core/util/SafeClose.java
+++ b/org.epic.perleditor/src/org/epic/core/util/SafeClose.java
@@ -6,7 +6,11 @@
  */
 package org.epic.core.util;
 
+import static org.epic.perleditor.Logger.INFO;
+
 import java.io.*;
+
+import org.epic.perleditor.Logger;
 
 /**
  * @author skoehler
@@ -18,11 +22,11 @@ public class SafeClose {
     public static void close(InputStream s)
     {
         if (s==null) return;
-        try { s.close(); } catch (Throwable e) { e.printStackTrace(); }
+        try { s.close(); } catch (Throwable e) { Logger.log(INFO, "Exception closing InputStream", e); }
     }
     public static void close(OutputStream s)
     {
         if (s==null) return;
-        try { s.close(); } catch (Throwable e) { e.printStackTrace(); }
+        try { s.close(); } catch (Throwable e) { Logger.log(INFO, "Exception closing OutputStream", e); }
     }
 }

--- a/org.epic.perleditor/src/org/epic/core/util/XMLUtilities.java
+++ b/org.epic.perleditor/src/org/epic/core/util/XMLUtilities.java
@@ -4,6 +4,9 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.variables.IStringVariableManager;
 import org.eclipse.core.variables.VariablesPlugin;
+import org.epic.perleditor.Logger;
+
+import static org.epic.perleditor.Logger.INFO;
 
 import java.io.*;
 import java.util.*;
@@ -48,7 +51,7 @@ public class XMLUtilities
         }
         catch (Exception e)
         {
-            e.printStackTrace();
+            Logger.logException(e);
         }
 
         return ignores.toArray(new String[ignores.size()]);
@@ -109,7 +112,7 @@ public class XMLUtilities
                         catch (CoreException e)
                         {
                             path = null;
-                            e.printStackTrace();
+                            Logger.log(INFO, "", e);
                         }
                     }
 
@@ -122,7 +125,7 @@ public class XMLUtilities
         }
         catch (Exception e)
         {
-            e.printStackTrace();
+            Logger.logException(e);
         }
 
         return includes.toArray(new String[includes.size()]);

--- a/org.epic.perleditor/src/org/epic/perleditor/Logger.java
+++ b/org.epic.perleditor/src/org/epic/perleditor/Logger.java
@@ -1,0 +1,178 @@
+package org.epic.perleditor;
+
+import java.util.StringTokenizer;
+
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Status;
+import org.osgi.framework.Bundle;
+
+/**
+ * Small convenience class to log messages to plugin's log file and also, if
+ * desired, the console. This class should only be used by classes in this
+ * plugin. Other plugins should make their own copy, with appropriate ID.
+ * 
+ * Copied from 
+ * <a href="https://git.eclipse.org/c/pdt/org.eclipse.pdt.git/tree/plugins/org.eclipse.php.core/src/org/eclipse/php/internal/core/Logger.java">Eclipse PDT</a>
+ */
+public class Logger
+{
+    private static final String PLUGIN_ID = PerlEditorPlugin.getPluginId();
+
+    private static final String TRACEFILTER_LOCATION = "/debug/tracefilter"; //$NON-NLS-1$
+
+    public static final int OK = IStatus.OK; // 0
+    public static final int INFO = IStatus.INFO; // 1
+    public static final int WARNING = IStatus.WARNING; // 2
+    public static final int ERROR = IStatus.ERROR; // 4
+
+    public static final int OK_DEBUG = 200 + OK;
+    public static final int INFO_DEBUG = 200 + INFO;
+    public static final int WARNING_DEBUG = 200 + WARNING;
+    public static final int ERROR_DEBUG = 200 + ERROR;
+
+    /**
+     * Adds message to log.
+     * 
+     * @param level
+     *            severity level of the message (OK, INFO, WARNING, ERROR,
+     *            OK_DEBUG, INFO_DEBUG, WARNING_DEBUG, ERROR_DEBUG)
+     * @param message
+     *            text to add to the log
+     * @param exception
+     *            exception thrown
+     */
+    protected static void _log(int level, String message, Throwable exception)
+    {
+        if (level == OK_DEBUG || level == INFO_DEBUG || level == WARNING_DEBUG
+            || level == ERROR_DEBUG)
+        {
+            if (!isDebugging()) return;
+        }
+
+        int severity = IStatus.OK;
+        switch (level)
+        {
+        case INFO_DEBUG:
+        case INFO:
+            severity = IStatus.INFO;
+            break;
+        case WARNING_DEBUG:
+        case WARNING:
+            severity = IStatus.WARNING;
+            break;
+        case ERROR_DEBUG:
+        case ERROR:
+            severity = IStatus.ERROR;
+        }
+        message = (message != null) ? message : "null"; //$NON-NLS-1$
+        Status statusObj = new Status(severity, PLUGIN_ID, severity, message,
+            exception);
+        Bundle bundle = Platform.getBundle(PLUGIN_ID);
+        if (bundle != null) Platform.getLog(bundle).log(statusObj);
+        debugMSG(statusObj.toString());
+
+    }
+
+    /**
+     * Prints message to log if category matches /debug/tracefilter option.
+     * 
+     * @param message
+     *            text to print
+     * @param category
+     *            category of the message, to be compared with
+     *            /debug/tracefilter
+     */
+    protected static void _trace(String category, String message,
+        Throwable exception)
+    {
+        if (isTracing(category))
+        {
+            message = (message != null) ? message : "null"; //$NON-NLS-1$
+            Status statusObj = new Status(IStatus.OK, PLUGIN_ID, IStatus.OK,
+                message, exception);
+            Bundle bundle = Platform.getBundle(PLUGIN_ID);
+            if (bundle != null) Platform.getLog(bundle).log(statusObj);
+        }
+    }
+
+    /**
+     * @return true if the platform is debugging
+     */
+    public static boolean isDebugging()
+    {
+        return Platform.inDebugMode();
+    }
+
+    /**
+     * Determines if currently tracing a category
+     * 
+     * @param category
+     * @return true if tracing category, false otherwise
+     */
+    public static boolean isTracing(String category)
+    {
+        if (!isDebugging()) return false;
+
+        String traceFilter = Platform
+            .getDebugOption(PLUGIN_ID + TRACEFILTER_LOCATION);
+        if (traceFilter != null)
+        {
+            StringTokenizer tokenizer = new StringTokenizer(traceFilter, ","); //$NON-NLS-1$
+            while (tokenizer.hasMoreTokens())
+            {
+                String cat = tokenizer.nextToken().trim();
+                if (category.equals(cat))
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    public static void log(int level, String message)
+    {
+        _log(level, message, null);
+    }
+
+    public static void log(int level, String message, Throwable exception)
+    {
+        _log(level, message, exception);
+    }
+
+    public static void logException(String message, Throwable exception)
+    {
+        _log(ERROR, message, exception);
+    }
+
+    public static void logException(Throwable exception)
+    {
+        _log(ERROR, exception.getMessage(), exception);
+    }
+
+    public static void traceException(String category, String message,
+        Throwable exception)
+    {
+        _trace(category, message, exception);
+    }
+
+    public static void traceException(String category, Throwable exception)
+    {
+        _trace(category, exception.getMessage(), exception);
+    }
+
+    public static void trace(String category, String message)
+    {
+        _trace(category, message, null);
+    }
+
+    public static void debugMSG(String msg)
+    {
+        if (PerlEditorPlugin.isDebugMode)
+        {
+            System.out.println(msg);
+        }
+    }
+
+}

--- a/org.epic.perleditor/src/org/epic/perleditor/PerlEditorPlugin.java
+++ b/org.epic.perleditor/src/org/epic/perleditor/PerlEditorPlugin.java
@@ -41,6 +41,13 @@ public class PerlEditorPlugin extends AbstractUIPlugin {
     private boolean requirePerlCheckPassed;
     private boolean requirePerlErrorDisplayed;
 
+    public static final boolean isDebugMode;
+
+    static {
+        String value = Platform.getDebugOption("org.epic.perleditor/debug"); //$NON-NLS-1$
+        isDebugMode = value != null && value.equalsIgnoreCase("true"); //$NON-NLS-1$
+    }
+
     /**
      * The constructor.
      */

--- a/org.epic.perleditor/src/org/epic/perleditor/editors/PerlEditor.java
+++ b/org.epic.perleditor/src/org/epic/perleditor/editors/PerlEditor.java
@@ -24,6 +24,7 @@ import org.eclipse.ui.texteditor.*;
 import org.eclipse.ui.views.contentoutline.IContentOutlinePage;
 import org.epic.core.model.*;
 import org.epic.core.util.FileUtilities;
+import org.epic.perleditor.Logger;
 import org.epic.perleditor.PerlEditorPlugin;
 import org.epic.perleditor.actions.*;
 import org.epic.perleditor.preferences.MarkOccurrencesPreferences;
@@ -133,7 +134,7 @@ public class PerlEditor extends TextEditor implements IPropertyChangeListener
         }
         catch (InterruptedException e)
         {
-            e.printStackTrace(); // TODO log it
+            Logger.logException(e);
         }
     }
 
@@ -653,7 +654,7 @@ public class PerlEditor extends TextEditor implements IPropertyChangeListener
         }
         catch (BadLocationException e)
         {
-            e.printStackTrace(); // TODO log it
+            Logger.logException(e);
         }
         finally
         {
@@ -1199,7 +1200,7 @@ public class PerlEditor extends TextEditor implements IPropertyChangeListener
                 }
                 catch (BadLocationException exception)
                 {
-                    // Should not happen
+                    Logger.logException(exception);
                 }
             }
             else // just move the caret

--- a/org.epic.perleditor/src/org/epic/perleditor/editors/util/PerlValidatorBase.java
+++ b/org.epic.perleditor/src/org/epic/perleditor/editors/util/PerlValidatorBase.java
@@ -12,6 +12,7 @@ import org.eclipse.jface.text.Document;
 import org.epic.core.Constants;
 import org.epic.core.PerlCore;
 import org.epic.core.util.PerlExecutor;
+import org.epic.perleditor.Logger;
 import org.epic.perleditor.PerlEditorPlugin;
 
 /**
@@ -25,7 +26,6 @@ import org.epic.perleditor.PerlEditorPlugin;
  */
 abstract class PerlValidatorBase
 {
-    private static final boolean DEBUG = true;
     private static int maxErrorsShown = 500;
     private static final int BUF_SIZE = 1024;
     
@@ -67,16 +67,15 @@ abstract class PerlValidatorBase
         if (isIgnoredPath(resource)) return;
 
         String perlOutput = runPerl(resource, sourceCode);
+        printPerlOutput(resource, perlOutput);
 
-        if (DEBUG) printPerlOutput(perlOutput);
-        
         List<String> lines = makeLinesList(perlOutput);
         boolean continued = false;
 
         // Markers have to be added in reverse order
         // Otherwise lower line number will appear at the end of the list
         for (int i = lines.size() - 1; i >= 0; i--)
-        {                
+        {
             String line = lines.get(i);
             
             // Is this a continuation of the line i-1?
@@ -88,10 +87,10 @@ abstract class PerlValidatorBase
             else
             {
                 if (continued) line += lines.get(i + 1);
-                continued = false;                
+                continued = false;
             }
             
-            ParsedErrorLine pline = new ParsedErrorLine(line, log);            
+            ParsedErrorLine pline = new ParsedErrorLine(line, log);
             IResource errorResource = getErrorResource(pline, resource);
 
             if (shouldIgnore(pline, errorResource)) continue;
@@ -126,7 +125,7 @@ abstract class PerlValidatorBase
                     String errorSourceCode;
                     
                     try
-                    {                    
+                    {
                         if (errorResource == resource) errorSourceCode = sourceCode;
                         else errorSourceCode = readSourceFile(errorResource);
                     
@@ -279,15 +278,16 @@ abstract class PerlValidatorBase
         return false;
     }
     
-    private void printPerlOutput(String perlOutput)
+    private void printPerlOutput(IResource resource, String perlOutput)
     {
-        if (perlOutput.indexOf("syntax OK") == -1)
+        if(perlOutput.indexOf("syntax OK") == -1)
         {
-            System.out.println("-----------------------------------------");
-            System.out.println("           OUTPUT");
-            System.out.println("-----------------------------------------");
-            System.out.println(perlOutput);
-            System.out.println("-----------------------------------------");
+            Logger.debugMSG("Syntax Error Validating: " + resource.getFullPath());
+            Logger.debugMSG("-----------------------------------------");
+            Logger.debugMSG("           OUTPUT");
+            Logger.debugMSG("-----------------------------------------");
+            Logger.debugMSG(perlOutput);
+            Logger.debugMSG("-----------------------------------------");
         }
     }
     

--- a/org.epic.perleditor/src/org/epic/perleditor/templates/TemplateSet.java
+++ b/org.epic.perleditor/src/org/epic/perleditor/templates/TemplateSet.java
@@ -27,6 +27,7 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
 import org.eclipse.core.runtime.CoreException;
+import org.epic.perleditor.Logger;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
@@ -83,6 +84,7 @@ public class TemplateSet {
                 if (stream != null)
                     stream.close();
             } catch (IOException e) {
+                Logger.logException(e);
             }
         }
     }
@@ -172,6 +174,7 @@ public class TemplateSet {
                 if (stream != null)
                     stream.close();
             } catch (IOException e) {
+                Logger.logException(e);
             }
         }
     }
@@ -237,23 +240,11 @@ public class TemplateSet {
     }
 
     private static void throwReadException(Throwable t) throws CoreException {
-        t.printStackTrace();
-        //PHPeclipsePlugin.log(t);
-        //		IStatus status= new
-        // JavaUIStatus(JavaStatusConstants.TEMPLATE_IO_EXCEPTION,
-        //			TemplateMessages.getString("TemplateSet.error.read"), t);
-        // //$NON-NLS-1$
-        //		throw new JavaUIException(status);
+        Logger.logException(t);
     }
 
     private static void throwWriteException(Throwable t) throws CoreException {
-        //PHPeclipsePlugin.log(t);
-        t.printStackTrace();
-        //		IStatus status= new
-        // JavaUIStatus(JavaStatusConstants.TEMPLATE_IO_EXCEPTION,
-        //			TemplateMessages.getString("TemplateSet.error.write"), t);
-        // //$NON-NLS-1$
-        //		throw new JavaUIException(status);
+        Logger.logException(t);
     }
 
     /**


### PR DESCRIPTION
Fixes https://sourceforge.net/p/e-p-i-c/feature-requests/36/

Logger copied over from Eclipse PDT. If I remember correctly, EPIC was forked from an early version of PDT anyway, so it might be ok to include the Logger from them, but at least today, they are not based on the same license. PDT uses EPL, while EPIC is CPL. If you have concerns I could as well reduce this class to a minimum-version that only logs exceptions.
