### PR TITLE
Fix mock setup for changed code (we're logging IResource.getFullPath())

### DIFF
--- a/org.epic.perleditor-test/src/org/epic/perleditor/editors/util/TestPerlValidator.java
+++ b/org.epic.perleditor-test/src/org/epic/perleditor/editors/util/TestPerlValidator.java
@@ -23,6 +23,8 @@ public class TestPerlValidator extends BaseTestCase
         cMockResource.setReturnValue(mockProject);
         mockResource.getProject();
         cMockResource.setReturnValue(mockProject);
+        mockResource.getFullPath();
+        cMockResource.setReturnValue(null);
         cMockResource.replay();
 
         // We expect a "broken pipe" IOException when feeding a large
@@ -31,7 +33,7 @@ public class TestPerlValidator extends BaseTestCase
         PerlValidatorStub validator = new PerlValidatorStub();
         
         try
-        {         
+        {
             validator.validate(
                 mockResource,
                 validator.readSourceFile(getFile("test.in/Tool.pm").getAbsolutePath(), null));


### PR DESCRIPTION
I broke a unit test when introducing the logger. This fixes the mock setup to expect a call to getFullPath()
