### PR TITLE
Open declaration extension point

### DIFF
--- a/org.epic.perleditor/plugin.xml
+++ b/org.epic.perleditor/plugin.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.0"?>
 <plugin>
+   <extension-point id="openDeclaration" name="Open Declaration Handlers" schema="schema/openDeclaration.exsd"/>
 
     <extension point="org.eclipse.ui.editors">
         <editor

--- a/org.epic.perleditor/schema/openDeclaration.exsd
+++ b/org.epic.perleditor/schema/openDeclaration.exsd
@@ -1,0 +1,102 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="org.epic.perleditor" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appInfo>
+         <meta.schema plugin="org.epic.perleditor" id="openDeclaration" name="Open Declaration Handlers"/>
+      </appInfo>
+      <documentation>
+         Allows contributing additional handlers to be considered during the &apos;Open Declaration&apos; functionality.
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appInfo>
+            <meta.element />
+         </appInfo>
+      </annotation>
+      <complexType>
+         <sequence>
+            <element ref="handler"/>
+         </sequence>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appInfo>
+                  <meta.attribute translatable="true"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="handler">
+      <complexType>
+         <attribute name="class" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appInfo>
+                  <meta.attribute kind="java" basedOn=":org.epic.perleditor.actions.IOpenDeclarationHandler"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="since"/>
+      </appInfo>
+      <documentation>
+         [Enter the first release in which this extension point appears.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="examples"/>
+      </appInfo>
+      <documentation>
+         [Enter extension point usage example here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="apiinfo"/>
+      </appInfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="implementation"/>
+      </appInfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/org.epic.perleditor/src/org/epic/perleditor/actions/ContributedOpenDeclarationHandler.java
+++ b/org.epic.perleditor/src/org/epic/perleditor/actions/ContributedOpenDeclarationHandler.java
@@ -1,0 +1,45 @@
+package org.epic.perleditor.actions;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.ITextSelection;
+import org.epic.core.model.SourceFile;
+import org.epic.perleditor.editors.PerlEditor;
+
+public class ContributedOpenDeclarationHandler extends AbstractOpenDeclaration
+{
+
+    private final PerlEditor editor;
+    private final IOpenDeclarationHandler handler;
+
+    public ContributedOpenDeclarationHandler(OpenDeclarationAction action, IOpenDeclarationHandler handler)
+    {
+        super(action);
+        this.editor = action.getEditor();
+        this.handler = handler;
+    }
+
+    protected IRegion findDeclaration(SourceFile sourceFile, String searchString) throws CoreException
+    {
+        return handler.findDeclaration(sourceFile, searchString);
+    }
+
+    @Override
+    protected String getLocalSearchString(String searchString)
+    {
+        return handler.getLocalSearchString(searchString);
+    }
+
+    @Override
+    protected String getSearchString(ITextSelection selection)
+    {
+        return handler.getSearchString(editor.getSourceFile(), selection);
+    }
+
+    @Override
+    protected String getTargetModule(String moduleName)
+    {
+        return handler.getTargetModule(moduleName);
+    }
+
+}

--- a/org.epic.perleditor/src/org/epic/perleditor/actions/IOpenDeclarationHandler.java
+++ b/org.epic.perleditor/src/org/epic/perleditor/actions/IOpenDeclarationHandler.java
@@ -1,0 +1,16 @@
+package org.epic.perleditor.actions;
+
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.ITextSelection;
+import org.epic.core.model.SourceFile;
+
+public interface IOpenDeclarationHandler
+{
+    public IRegion findDeclaration(SourceFile sourceFile, String searchString);
+
+    public String getLocalSearchString(String searchString);
+
+    public String getSearchString(SourceFile sourceFile, ITextSelection selection);
+
+    public String getTargetModule(String moduleName);
+}

--- a/org.epic.perleditor/src/org/epic/perleditor/actions/OpenDeclarationAction.java
+++ b/org.epic.perleditor/src/org/epic/perleditor/actions/OpenDeclarationAction.java
@@ -51,8 +51,9 @@ public class OpenDeclarationAction extends PerlEditorAction
                     contributedActions.add(new ContributedOpenDeclarationHandler(this, (IOpenDeclarationHandler)handler));
                 }
             } catch ( CoreException e ) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
+                PerlEditorPlugin.getDefault().getLog().log(
+                        new Status(IStatus.WARNING, PerlEditorPlugin.getUniqueIdentifier(),
+                        "failed to load openDeclaration extension", e));
             }
         }
     }

--- a/org.epic.perleditor/src/org/epic/perleditor/actions/OpenDeclarationAction.java
+++ b/org.epic.perleditor/src/org/epic/perleditor/actions/OpenDeclarationAction.java
@@ -1,5 +1,11 @@
 package org.epic.perleditor.actions;
 
+import java.util.LinkedList;
+import java.util.List;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.swt.widgets.Shell;
@@ -24,6 +30,7 @@ public class OpenDeclarationAction extends PerlEditorAction
 {
     private final OpenSubDeclaration openSub;
     private final OpenPackageDeclaration openPackage;
+    private final List<AbstractOpenDeclaration> contributedActions;
     
     //~ Constructors
 
@@ -33,6 +40,21 @@ public class OpenDeclarationAction extends PerlEditorAction
         
         this.openSub = new OpenSubDeclaration(this);
         this.openPackage = new OpenPackageDeclaration(this);
+        this.contributedActions = new LinkedList<AbstractOpenDeclaration>();
+
+        IConfigurationElement[] config = Platform.getExtensionRegistry().getConfigurationElementsFor("org.epic.perleditor.openDeclaration");
+        for (IConfigurationElement cfg: config) {
+            Object handler;
+            try {
+                handler = cfg.createExecutableExtension("class");
+                if ( handler instanceof IOpenDeclarationHandler ) {
+                    contributedActions.add(new ContributedOpenDeclarationHandler(this, (IOpenDeclarationHandler)handler));
+                }
+            } catch ( CoreException e ) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
+        }
     }
     
     //~ Methods
@@ -46,7 +68,18 @@ public class OpenDeclarationAction extends PerlEditorAction
         if (!res1.isFound())
         {
             AbstractOpenDeclaration.Result res2 = openPackage.run(selection);
-            if (!res2.isFound()) reportFailure(res1);
+            if (!res2.isFound())
+            {
+                for (AbstractOpenDeclaration decl: contributedActions)
+                {
+                    AbstractOpenDeclaration.Result res3 = decl.run(selection);
+                    if (res3.isFound())
+                    {
+                        return;
+                    }
+                }
+                reportFailure(res2);
+            }
         }
     }
     
@@ -56,7 +89,18 @@ public class OpenDeclarationAction extends PerlEditorAction
         if (!res1.isFound())
         {
             AbstractOpenDeclaration.Result res2 = openPackage.run();
-            if (!res2.isFound()) reportFailure(res1);
+            if (!res2.isFound())
+            {
+                for (AbstractOpenDeclaration decl: contributedActions)
+                {
+                    AbstractOpenDeclaration.Result res3 = decl.run();
+                    if (res3.isFound())
+                    {
+                        return;
+                    }
+                }
+                reportFailure(res2);
+            }
         }
     }
     

--- a/org.epic.perleditor/src/org/epic/perleditor/actions/OpenDeclarationAction.java
+++ b/org.epic.perleditor/src/org/epic/perleditor/actions/OpenDeclarationAction.java
@@ -5,7 +5,9 @@ import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.swt.widgets.Shell;


### PR DESCRIPTION
This extension point permits providing additional algorithms for
implementing the 'Open Declaration' functionality such that it works not
only for packages and subs.

The AbstractOpenDeclaration class has package-visibility and exposes a
bit more functionality than I'd like, so I decided to introduce anew
IOpenDeclarationHandler interface and expect extensions to implement
that. A ContributedOpenDeclarationHandler action wraps this interface
and forwards all calls.