### PR TITLE
Required file resolver extension point

### DIFF
--- a/org.epic.perleditor/plugin.xml
+++ b/org.epic.perleditor/plugin.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.0"?>
 <plugin>
+   <extension-point id="requiredFileResolver" name="Extra Required File Resolvers" schema="schema/requiredFileResolver.exsd"/>
 
     <extension point="org.eclipse.ui.editors">
         <editor

--- a/org.epic.perleditor/schema/requiredFileResolver.exsd
+++ b/org.epic.perleditor/schema/requiredFileResolver.exsd
@@ -1,0 +1,102 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="org.epic.perleditor" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appInfo>
+         <meta.schema plugin="org.epic.perleditor" id="org.epic.requiredFileResolver" name="Required File Resolver"/>
+      </appInfo>
+      <documentation>
+         Permits customizing the logic for mapping the argument to the &apos;required&apos; statement to an actual File object. Used for the &apos;Open Declaration&apos; functionality.
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appInfo>
+            <meta.element />
+         </appInfo>
+      </annotation>
+      <complexType>
+         <sequence>
+            <element ref="resolver"/>
+         </sequence>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appInfo>
+                  <meta.attribute translatable="true"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="resolver">
+      <complexType>
+         <attribute name="class" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appInfo>
+                  <meta.attribute kind="java" basedOn=":org.epic.perleditor.IRequiredFileResolver"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="since"/>
+      </appInfo>
+      <documentation>
+         [Enter the first release in which this extension point appears.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="examples"/>
+      </appInfo>
+      <documentation>
+         [Enter extension point usage example here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="apiinfo"/>
+      </appInfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="implementation"/>
+      </appInfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/org.epic.perleditor/schema/requiredFileResolver.exsd
+++ b/org.epic.perleditor/schema/requiredFileResolver.exsd
@@ -55,7 +55,7 @@
                   
                </documentation>
                <appInfo>
-                  <meta.attribute kind="java" basedOn=":org.epic.perleditor.IRequiredFileResolver"/>
+                  <meta.attribute kind="java" basedOn=":org.epic.perleditor.actions.IRequiredFileResolver"/>
                </appInfo>
             </annotation>
          </attribute>

--- a/org.epic.perleditor/src/org/epic/perleditor/IRequiredFileResolver.java
+++ b/org.epic.perleditor/src/org/epic/perleditor/IRequiredFileResolver.java
@@ -1,0 +1,10 @@
+package org.epic.perleditor;
+
+import java.io.File;
+
+public interface IRequiredFileResolver
+{
+
+    File resolveRequiredFile(String identifier);
+
+}

--- a/org.epic.perleditor/src/org/epic/perleditor/actions/AbstractOpenDeclaration.java
+++ b/org.epic.perleditor/src/org/epic/perleditor/actions/AbstractOpenDeclaration.java
@@ -18,7 +18,6 @@ import org.epic.core.PerlProject;
 import org.epic.core.model.*;
 import org.epic.core.model.Package;
 import org.epic.core.util.FileUtilities;
-import org.epic.perleditor.IRequiredFileResolver;
 import org.epic.perleditor.PerlEditorPlugin;
 import org.epic.perleditor.editors.*;
 import org.epic.perleditor.editors.perl.SourceElement;

--- a/org.epic.perleditor/src/org/epic/perleditor/actions/AbstractOpenDeclaration.java
+++ b/org.epic.perleditor/src/org/epic/perleditor/actions/AbstractOpenDeclaration.java
@@ -79,8 +79,9 @@ abstract class AbstractOpenDeclaration
                     requiredFileResolvers.add( (IRequiredFileResolver)handler );
                 }
             } catch ( CoreException e ) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
+                PerlEditorPlugin.getDefault().getLog().log(
+                        new Status(IStatus.WARNING, PerlEditorPlugin.getUniqueIdentifier(),
+                        "failed to load requiredFileResolver extension", e));
             }
         }
     }

--- a/org.epic.perleditor/src/org/epic/perleditor/actions/IRequiredFileResolver.java
+++ b/org.epic.perleditor/src/org/epic/perleditor/actions/IRequiredFileResolver.java
@@ -1,4 +1,4 @@
-package org.epic.perleditor;
+package org.epic.perleditor.actions;
 
 import java.io.File;
 


### PR DESCRIPTION
This patch introduces a new extension point which permits expressing
custom algorithms for locating files specified with the 'require'
statement. Such handlers will be considered first by the 'Open
Declaration' functionality which traverses the set of included files
when trying to look for a declaration.

This allows implementing custom logic for expressions like

  require customGlobalObject->myLibraryFile;

or similar: users can manually evaluate the variable name and return an
appropriate File object (or null, if the given string cannot be resolved
to any File).
