### PR TITLE
Remove references to non-existant files

### DIFF
--- a/org.epic.perleditor/build.properties
+++ b/org.epic.perleditor/build.properties
@@ -1,11 +1,8 @@
 bin.includes = plugin.xml,\
-               HelpContexts.xml,\
-               HelpToc.xml,\
                ChangeLog,\
                .,\
                icons/,\
                perlutils/,\
-               html/,\
                about.ini,\
                about.html,\
                epicAbout.jpg,\


### PR DESCRIPTION
The build.properties file in the org.epic.perleditor bundle refers to files that do not exist. This change removes those references.