### PR TITLE
Fix use of deprecated API that was removed in Oxygen

### DIFF
--- a/org.epic.perleditor/src/org/epic/core/model/SourceFile.java
+++ b/org.epic.perleditor/src/org/epic/core/model/SourceFile.java
@@ -4,7 +4,7 @@ import java.util.*;
 
 import org.eclipse.core.runtime.*;
 import org.eclipse.jface.text.*;
-import org.eclipse.jface.util.ListenerList;
+import org.eclipse.core.runtime.ListenerList;
 import org.epic.core.parser.*;
 import org.epic.perleditor.PerlEditorPlugin;
 import org.epic.perleditor.editors.PartitionTypes;
@@ -19,7 +19,7 @@ import org.epic.perleditor.editors.PerlPartitioner;
  */
 public class SourceFile
 {
-    private final ListenerList listeners = new ListenerList(1);
+    private final ListenerList listeners = new ListenerList();
     private final ILog log;
     private final IDocument doc;
     private List<PODComment> pods;


### PR DESCRIPTION
The jface listenerlist API has been deprecated since 2005 and was replaced by an implementation in the core runtime. The jface version is removed starting from Oxygen.

This change allows epic-ide to continue to work when Eclipse Oxygen is released. 