### PR TITLE
Fix working under Eclipse 4.8.

### DIFF
--- a/org.epic.perleditor/src/org/epic/perleditor/preferences/CodeAssistPreferencePage.java
+++ b/org.epic.perleditor/src/org/epic/perleditor/preferences/CodeAssistPreferencePage.java
@@ -1,10 +1,14 @@
 package org.epic.perleditor.preferences;
 
-import org.eclipse.jface.preference.*;
+import org.eclipse.jface.preference.BooleanFieldEditor;
+import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.preference.IntegerFieldEditor;
+import org.eclipse.jface.preference.StringFieldEditor;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
-import org.eclipse.ui.help.WorkbenchHelp;
+import org.eclipse.ui.PlatformUI;
 import org.epic.perleditor.PerlEditorPlugin;
 
 
@@ -46,7 +50,7 @@ public class CodeAssistPreferencePage
      */
     public void createControl(Composite parent) {
         super.createControl(parent);
-        WorkbenchHelp.setHelp(getControl(), getPreferenceHelpContextID());
+        PlatformUI.getWorkbench().getHelpSystem().setHelp(getControl(), getPreferenceHelpContextID());
     }
     
     protected String getPreferenceHelpContextID() {

--- a/org.epic.perleditor/src/org/epic/perleditor/preferences/SourceFormatterPreferencePage.java
+++ b/org.epic.perleditor/src/org/epic/perleditor/preferences/SourceFormatterPreferencePage.java
@@ -1,10 +1,13 @@
 package org.epic.perleditor.preferences;
 
-import org.eclipse.jface.preference.*;
+import org.eclipse.jface.preference.BooleanFieldEditor;
+import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.preference.StringFieldEditor;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
-import org.eclipse.ui.help.WorkbenchHelp;
+import org.eclipse.ui.PlatformUI;
 import org.epic.core.preferences.LabelFieldEditor;
 import org.epic.core.preferences.SpacerFieldEditor;
 import org.epic.perleditor.PerlEditorPlugin;
@@ -48,7 +51,7 @@ public class SourceFormatterPreferencePage
      */
     public void createControl(Composite parent) {
         super.createControl(parent);
-        WorkbenchHelp.setHelp(getControl(), getPreferenceHelpContextID());
+        PlatformUI.getWorkbench().getHelpSystem().setHelp(getControl(), getPreferenceHelpContextID());
     }
     
     protected String getPreferenceHelpContextID() {

--- a/org.epic.perleditor/src/org/epic/perleditor/preferences/TaskTagsPreferencePage.java
+++ b/org.epic.perleditor/src/org/epic/perleditor/preferences/TaskTagsPreferencePage.java
@@ -1,12 +1,12 @@
 package org.epic.perleditor.preferences;
 
-import org.eclipse.jface.preference.*;
+import org.eclipse.jface.preference.BooleanFieldEditor;
+import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.IEditorPart;
-import org.eclipse.ui.IWorkbenchPreferencePage;
 import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPreferencePage;
 import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.help.WorkbenchHelp;
 import org.epic.perleditor.PerlEditorPlugin;
 import org.epic.perleditor.editors.PerlEditor;
 
@@ -26,7 +26,7 @@ implements IWorkbenchPreferencePage, ITaskTagConstants {
     
     public void createControl(Composite parent) {
         super.createControl(parent);
-        WorkbenchHelp.setHelp(getControl(), getPreferenceHelpContextID());    
+        PlatformUI.getWorkbench().getHelpSystem().setHelp(getControl(), getPreferenceHelpContextID());    
     }
     
     /* (non-Javadoc)


### PR DESCRIPTION
WorkbenchHelp  has been deprecated since 2005 and is removed in this
version. Code adjusted to the new way.